### PR TITLE
Improve `--compile-args` handling

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -26,4 +26,4 @@ runs:
 
     - name: Verify compiled pipelines
       shell: bash
-      run: python "${{ github.action_path }}/verify_kfp_compiled.py" --map-file "${{ inputs.pipelines-map-file }}" --compile-args "${{ inputs.compile-args || '' }}" ${{ inputs.modified-only == 'true' && '--modified-only' || '' }}
+      run: python "${{ github.action_path }}/verify_kfp_compiled.py" --map-file "${{ inputs.pipelines-map-file }}" "--compile-args=${{ inputs.compile-args || '' }}" ${{ inputs.modified-only == 'true' && '--modified-only' || '' }}


### PR DESCRIPTION
- Switched to `--compile-args=<value>` format for proper argument parsing.
- Updated action and test logic to support values starting with dashes.
- Added test cases to validate new syntax handling.