### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/fix-dependabot-requirements.yml
+++ b/.github/workflows/fix-dependabot-requirements.yml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ github.token }}
           ref: ${{ github.head_ref }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Regenerate requirements.txt
         shell: bash

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -10,10 +10,10 @@ jobs:
   markdown-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "20"
 

--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -10,16 +10,16 @@ jobs:
   precommit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Set up Python
         run: uv python install 3.12
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "20"
 

--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -10,10 +10,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Set up Python
         run: uv python install 3.12

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Set up Python
         run: uv python install 3.12

--- a/.github/workflows/ty-check.yml
+++ b/.github/workflows/ty-check.yml
@@ -10,10 +10,10 @@ jobs:
   ty-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Set up Python
         run: uv python install 3.12

--- a/.github/workflows/uv-lock-check.yml
+++ b/.github/workflows/uv-lock-check.yml
@@ -10,15 +10,15 @@ jobs:
   uv-lock-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
       - name: Check lock file
-        uses: hbelmiro/uv-lock-check@v0.2.0
+        uses: hbelmiro/uv-lock-check@814bb91b9521353fce69abced9210c8b42467d6d # v0.2.0
 
       - name: Check integration requirements sync
-        uses: hbelmiro/uv-lock-check@v0.2.0
+        uses: hbelmiro/uv-lock-check@814bb91b9521353fce69abced9210c8b42467d6d # v0.2.0
         with:
           command: uv export --package integration-env --format requirements-txt --no-emit-project -o tests/integration/requirements.txt


### PR DESCRIPTION
## Summary

- Replace mutable tag references with pinned commit SHAs in all GitHub Actions workflow files
- Original tag is preserved as an inline comment for readability

This improves supply-chain security by ensuring workflows use exact, immutable revisions.